### PR TITLE
Add task generator and tests

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+const tasks = JSON.parse(fs.readFileSync('tasks.json', 'utf8'));
+let md = '| id | title |\n| --- | --- |\n';
+for (const t of tasks) {
+  md += `| ${t.id} | ${t.title} |\n`;
+}
+fs.writeFileSync('tasks.md', md);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "codex-demo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "generate": "node generate.js",
+    "test": "vitest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,3 @@
+[
+  {"id": 1, "title": "Buy bitcoin"}
+]

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,3 @@
+| id | title |
+| --- | --- |
+| 1 | Buy bitcoin |

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process';
+import { expect, test } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+
+test('pnpm generate creates tasks.md with expected content', () => {
+  execSync('pnpm run generate');
+  expect(existsSync('tasks.md')).toBe(true);
+  const content = readFileSync('tasks.md', 'utf8');
+  expect(content).toContain('Buy bitcoin');
+});


### PR DESCRIPTION
## Summary
- add `tasks.json` for task data
- create `generate.js` script to build a Markdown table
- commit generated `tasks.md`
- configure `package.json` with `generate` and `test` scripts and vitest dev dependency
- add `tests/convert.test.js` verifying markdown generation

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eb956518832c9413f162453d8be9